### PR TITLE
Revert "Use the Gemfile in the current directory or ancestor directories"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -173,7 +173,6 @@ if type rbenv &> /dev/null; then
   alias rehash='rbenv rehash && rehash'
   rehash
 fi
-export RUBYGEMS_GEMDEPS=-
 
 
 #


### PR DESCRIPTION
This reverts commit d5feb4efffae5a533860bfdb90626f6a0e449261.