### PR TITLE
Revert "Give priority to the directory of the Dropbox"

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -46,8 +46,8 @@
 	lineNumber = true
 
 [ghq]
-	root = ~/Dropbox/src
 	root = ~/src
+	root = ~/Dropbox/src
 
 [pager]
 	log  = ~/.git.d/bin/diff-pager


### PR DESCRIPTION
Reverts elim/dotfiles#76

I had forgotten that, this setting also affects `ghq get`.