### PR TITLE
feat(emacs): use maximized instead of fullscreen on macOS

### DIFF
--- a/home/takeru/features/emacs/init.el
+++ b/home/takeru/features/emacs/init.el
@@ -236,16 +236,17 @@
   (leaf frame
     :if window-system
     :preface
-    (defun elim:frame-fullscreen ()
-      ;; FIXME: Sometimes may become native full screen on macOS even
-      ;;        the ns-use-native-fullscreen is nil (especially on
-      ;;        startup).
-      (set-frame-parameter nil 'fullscreen 'fullboth))
+    (defun elim:frame-startup-state ()
+      ;; Avoid macOS fullscreen spaces: maximizing keeps the notch clear
+      ;; without opting into native fullscreen animations.
+      (set-frame-parameter
+       nil 'fullscreen
+       (if (eq system-type 'darwin) 'maximized 'fullboth)))
     :config
     (add-to-list 'default-frame-alist '(ns-transparent-titlebar . t))
     (add-to-list 'default-frame-alist '(ns-appearance . dark))
     :custom ((line-spacing . 4))
-    :hook (window-setup-hook . elim:frame-fullscreen))
+    :hook (window-setup-hook . elim:frame-startup-state))
   (leaf *completion
     :url https://blog.tomoya.dev/posts/a-new-wave-has-arrived-at-emacs
     :url https://emacs-jp.slack.com/archives/C1B5WTJLQ/p1623851956426000


### PR DESCRIPTION
## Summary

- On MacBook Pro with notch, Emacs launched in native fullscreen (`fullboth`) overlapped the first line with the display notch
- macOS native fullscreen also brings Space-switching and animated transitions, which don't fit the goal of simply a wide editing area
- Renamed `elim:frame-fullscreen` → `elim:frame-startup-state` and branched on `system-type`: darwin gets `'maximized`, other systems keep `'fullboth`

## Test plan

- [x] Launch Emacs on macOS — window should open maximized without entering native fullscreen Space
- [x] Launch Emacs on non-macOS — window should open fullscreen as before (`fullboth`)